### PR TITLE
Update V2M-MPS3-SSE-300-FVP board layer

### DIFF
--- a/layer/Board/V2M-MPS3-SSE-300-FVP/Board.clayer
+++ b/layer/Board/V2M-MPS3-SSE-300-FVP/Board.clayer
@@ -37,7 +37,7 @@
 
   <packages>
     <package name="CMSIS" vendor="ARM"/>
-    <package name="V2M_MPS3_SSE_300_BSP" vendor="ARM"/>
+    <package name="V2M_MPS3_SSE_300_BSP" vendor="ARM" version="1.2.0:1.2.0"/>
     <package name="ARM_Compiler" vendor="Keil"/>
   </packages>
 


### PR DESCRIPTION
- use fixed ARM.V2M_MPS3_SSE_300_BSP 1.2.0 pack

Reference projects will be synchronized in future update